### PR TITLE
Fix vLLM hanging at NCCL stage with multiple GPUs

### DIFF
--- a/docker/vllm-librosa/Dockerfile
+++ b/docker/vllm-librosa/Dockerfile
@@ -1,6 +1,13 @@
 # Use the base image
 FROM vllm/vllm-openai:v0.6.4.post1
 
+# NCCL environment variables for multi-GPU stability
+# Prevents hanging at NCCL initialization on certain hardware configurations
+ENV NCCL_P2P_DISABLE=1
+ENV NCCL_IB_DISABLE=1
+ENV NCCL_DEBUG=WARN
+ENV NCCL_SOCKET_IFNAME=eth0
+
 # Install librosa
 RUN pip install librosa
 


### PR DESCRIPTION
## Summary
- Adds NCCL environment variables to the vllm-librosa Dockerfile to prevent pods from getting stuck at NCCL initialization with 100% GPU utilization on multi-GPU setups
- Disables P2P and InfiniBand communication which cause hangs on certain cloud hardware configurations
- Adds NCCL_DEBUG=WARN for better debugging visibility

Fixes #15

## Changes
Added the following ENV variables to `docker/vllm-librosa/Dockerfile`:
- `NCCL_P2P_DISABLE=1` - Disables peer-to-peer communication that causes hangs on some hardware
- `NCCL_IB_DISABLE=1` - Disables InfiniBand for cloud setups without IB
- `NCCL_DEBUG=WARN` - Enables warning-level NCCL logging for debugging
- `NCCL_SOCKET_IFNAME=eth0` - Forces use of ethernet interface for communication

## Test plan
- [ ] Build the Docker image with the updated Dockerfile
- [ ] Deploy vLLM with tensor parallelism across multiple GPUs
- [ ] Verify NCCL initialization completes without hanging
- [ ] Confirm model inference works correctly with multi-GPU setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)